### PR TITLE
Jason/script obs mode

### DIFF
--- a/esw-integration-test/src/test/scala/esw/ocs/script/ScriptLoaderTest.scala
+++ b/esw-integration-test/src/test/scala/esw/ocs/script/ScriptLoaderTest.scala
@@ -29,6 +29,7 @@ class ScriptLoaderTest extends BaseTestSuite {
   private val iAlarmService           = mock[IAlarmService]
   private val sequencerClientFactory  = mock[(Subsystem, ObsMode) => CompletionStage[SequencerApi]]
   private val prefix                  = Prefix("ESW.filter.wheel")
+  private val obsMode                 = mock[ObsMode]
   private val config                  = mock[Config]
   private val heartbeatInterval       = Duration.ofSeconds(3)
 
@@ -38,6 +39,7 @@ class ScriptLoaderTest extends BaseTestSuite {
   val scriptContext = new ScriptContext(
     heartbeatInterval,
     prefix,
+    obsMode,
     logger,
     sequenceOperatorFactory,
     actorSystem,

--- a/esw-ocs/esw-ocs-app/src/main/scala/esw/ocs/app/wiring/SequencerWiring.scala
+++ b/esw-ocs/esw-ocs-app/src/main/scala/esw/ocs/app/wiring/SequencerWiring.scala
@@ -108,6 +108,7 @@ private[ocs] class SequencerWiring(
   lazy val scriptContext = new ScriptContext(
     heartbeatInterval,
     prefix,
+    obsMode,
     jLogger,
     sequenceOperatorFactory,
     actorSystem,

--- a/esw-ocs/esw-ocs-dsl-kt/src/main/kotlin/esw/ocs/dsl/core/Script.kt
+++ b/esw-ocs/esw-ocs-dsl-kt/src/main/kotlin/esw/ocs/dsl/core/Script.kt
@@ -7,6 +7,7 @@ import csw.params.commands.SequenceCommand
 import csw.params.commands.Setup
 import csw.prefix.models.Prefix
 import csw.time.core.models.UTCTime
+import esw.ocs.api.models.ObsMode
 import esw.ocs.dsl.highlevel.CswHighLevelDsl
 import esw.ocs.dsl.highlevel.models.ScriptError
 import esw.ocs.dsl.internal.ScriptWiring
@@ -33,6 +34,7 @@ sealed class BaseScript(wiring: ScriptWiring) : CswHighLevelDsl(wiring.cswServic
     internal open val scriptDsl: ScriptDsl by lazy { ScriptDsl(wiring.scriptContext.sequenceOperatorFactory(), logger, strandEc, shutdownTask) }
     override val isOnline: Boolean get() = scriptDsl.isOnline
     final override val prefix: String = wiring.scriptContext.prefix().toString()
+    val obsMode: ObsMode = wiring.scriptContext.obsMode()
     override val sequencerObserveEvent: SequencerObserveEvent = SequencerObserveEvent(Prefix.apply(prefix))
 
     private val exceptionHandler = CoroutineExceptionHandler { _, exception ->

--- a/esw-ocs/esw-ocs-dsl-kt/src/main/kotlin/esw/ocs/dsl/core/Script.kt
+++ b/esw-ocs/esw-ocs-dsl-kt/src/main/kotlin/esw/ocs/dsl/core/Script.kt
@@ -34,7 +34,7 @@ sealed class BaseScript(wiring: ScriptWiring) : CswHighLevelDsl(wiring.cswServic
     internal open val scriptDsl: ScriptDsl by lazy { ScriptDsl(wiring.scriptContext.sequenceOperatorFactory(), logger, strandEc, shutdownTask) }
     override val isOnline: Boolean get() = scriptDsl.isOnline
     final override val prefix: String = wiring.scriptContext.prefix().toString()
-    val obsMode: ObsMode = wiring.scriptContext.obsMode()
+    final override val obsMode: ObsMode = wiring.scriptContext.obsMode()
     override val sequencerObserveEvent: SequencerObserveEvent = SequencerObserveEvent(Prefix.apply(prefix))
 
     private val exceptionHandler = CoroutineExceptionHandler { _, exception ->

--- a/esw-ocs/esw-ocs-dsl-kt/src/main/kotlin/esw/ocs/dsl/highlevel/CswHighLevelDsl.kt
+++ b/esw-ocs/esw-ocs-dsl-kt/src/main/kotlin/esw/ocs/dsl/highlevel/CswHighLevelDsl.kt
@@ -29,6 +29,7 @@ interface CswHighLevelDslApi : CswServices, LocationServiceDsl, ConfigServiceDsl
         AlarmServiceDsl, TimeServiceDsl, DatabaseServiceDsl, LoopDsl {
     val isOnline: Boolean
     val prefix: String
+    val obsMode: ObsMode
     val sequencerObserveEvent: SequencerObserveEvent
 
     fun presetStart(obsId: ObsId): ObserveEvent       = sequencerObserveEvent.presetStart(obsId)

--- a/esw-ocs/esw-ocs-dsl-kt/src/test/kotlin/esw/ocs/dsl/highlevel/CswHighLevelDslTest.kt
+++ b/esw-ocs/esw-ocs-dsl-kt/src/test/kotlin/esw/ocs/dsl/highlevel/CswHighLevelDslTest.kt
@@ -5,6 +5,7 @@ import akka.actor.typed.SpawnProtocol
 import com.typesafe.config.Config
 import csw.location.api.javadsl.ILocationService
 import csw.location.api.scaladsl.LocationService
+import esw.ocs.api.models.ObsMode
 import esw.ocs.dsl.highlevel.models.Assembly
 import esw.ocs.dsl.highlevel.models.HCD
 import esw.ocs.dsl.highlevel.models.Prefix
@@ -34,7 +35,7 @@ class CswHighLevelDslTest {
     private val cswServices: CswServices = mockk()
     private val locationService: LocationService = mockk()
     private val iLocationService: ILocationService = mockk()
-    private val scriptContext = ScriptContext(mockk(), Prefix("TCS.filter.wheel"), mockk(), mockk(), system, mockk(), mockk(), mockk(), config)
+    private val scriptContext = ScriptContext(mockk(), Prefix("TCS.filter.wheel"), mockk(), mockk(), mockk(), system, mockk(), mockk(), mockk(), config)
 
     init {
         every { config.getConfig("csw-alarm") }.returns(alarmConfig)
@@ -52,6 +53,7 @@ class CswHighLevelDslTest {
         override val coroutineScope: CoroutineScope = mockk()
         override val isOnline: Boolean get() = true
         override val prefix: String = scriptContext.prefix().toString()
+        override val obsMode: ObsMode = scriptContext.obsMode()
         override val sequencerObserveEvent: SequencerObserveEvent = SequencerObserveEvent(Prefix(prefix))
         override val actorSystem: ActorSystem<SpawnProtocol.Command> = system
 

--- a/esw-ocs/esw-ocs-impl/src/main/scala/esw/ocs/impl/script/ScriptContext.scala
+++ b/esw-ocs/esw-ocs-impl/src/main/scala/esw/ocs/impl/script/ScriptContext.scala
@@ -16,6 +16,7 @@ import esw.ocs.impl.core.SequenceOperator
 class ScriptContext(
     val heartbeatInterval: Duration,
     val prefix: Prefix,
+    val obsMode: ObsMode,
     val jLogger: ILogger,
     val sequenceOperatorFactory: () => SequenceOperator,
     val actorSystem: ActorSystem[SpawnProtocol.Command],


### PR DESCRIPTION
I've been working on migrating the scripts we developed for FDR into Kotlin (a push to the sequencer-scripts/examples-dev branch will come soon), and it occurred to me that it would be useful for a script writer to know what the observing mode of the sequencer is that the script is handling, especially since there may be cases where a script is used for multiple observing modes.  Another common usage would be for the OCS sequencer to use the same observing mode for the lower level sequencers it is commanding.  I didn't see how this could be done, so this PR is an attempt at adding that functionality as a DSL global, like the prefix DSL, which is for the prefix of the sequencer.  I ended up putting it in CswHighLevelDsl because I wasn't sure how else to get it in scope.  This may or may not be the best place for it, so it can be moved if you think it's appropriate (only because obs mode is an ESW thing and not really a CSW thing).  I also didn't write any tests for this, but I didn't see any tests for the prefix DSL either. I don't think we have a requirement to provide the obsMode explicitly, so we are probably ok, but again, I defer to your judgement.